### PR TITLE
Improve perf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/*
 .cache/
 .vscode/
+.zed/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,3 +49,17 @@ target_compile_options(${EXE_NAME} PRIVATE -Wall -Wextra)
 target_link_libraries(${EXE_NAME} PRIVATE SFML::Graphics)
 
 file(COPY ${CMAKE_SOURCE_DIR}/assets DESTINATION ${CMAKE_BINARY_DIR})
+
+add_custom_target(debug
+    COMMAND "${CMAKE_COMMAND}" -DCMAKE_BUILD_TYPE=debug -S "${CMAKE_SOURCE_DIR}" -B "${CMAKE_BINARY_DIR}"
+    COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}"
+    USES_TERMINAL
+    COMMENT "Configuring to Debug mode and building ..."
+)
+
+add_custom_target(release
+    COMMAND "${CMAKE_COMMAND}" -DCMAKE_BUILD_TYPE=release -S "${CMAKE_SOURCE_DIR}" -B "${CMAKE_BINARY_DIR}"
+    COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}"
+    USES_TERMINAL
+    COMMENT "Configuring to Release mode and building ..."
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,12 +13,17 @@ endif()
 # make CMAKE_BUILD_TYPE case-insensitive
 string(TOLOWER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE)
 
+# executable name
+set(EXE_NAME ${CMAKE_PROJECT_NAME})
+
 # set compile flags for build types
 if(CMAKE_BUILD_TYPE STREQUAL "debug")
     set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g -DDEBUG")
+    set(EXE_NAME "RPEngineDebug")
     message(STATUS "Building in Debug mode")
 elseif(CMAKE_BUILD_TYPE STREQUAL "release")
     set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
+    set(EXE_NAME "RPEngine")
     message(STATUS "Building in Release mode")
 endif()
 
@@ -37,10 +42,10 @@ set(SOURCES
     src/ui/Renderer.cpp
 )
 
-add_executable(${CMAKE_PROJECT_NAME} ${SOURCES})
-target_compile_features(${CMAKE_PROJECT_NAME} PRIVATE cxx_std_17)
-target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/include)
-target_compile_options(${CMAKE_PROJECT_NAME} PRIVATE -Wall -Wextra)
-target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE SFML::Graphics)
+add_executable(${EXE_NAME} ${SOURCES})
+target_compile_features(${EXE_NAME} PRIVATE cxx_std_17)
+target_include_directories(${EXE_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_compile_options(${EXE_NAME} PRIVATE -Wall -Wextra)
+target_link_libraries(${EXE_NAME} PRIVATE SFML::Graphics)
 
 file(COPY ${CMAKE_SOURCE_DIR}/assets DESTINATION ${CMAKE_BINARY_DIR})

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Release build can handle about 55k particles at 60 fps, 100k particles at about
   `Simulator::spatialGridBroadphase()`
 - [x] change particle drawing to vertex-based
 - [x] add radial push
+- [ ] BIG add instructions for controls!!!
 - [ ] MAYBE add orbiting
 - [ ] fix particles exploding when compacted w/ Verlet integration
 - [ ] add multithreading

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 - [x] add a Verlet integration based resolver to `Simulator`
 - [x] implement spatial grid broad-phase
 - [x] add debug and release builds
-- [ ] implement SpatialGrid class and move some stuff out of
+- [x] implement SpatialGrid class and move some stuff out of
   `Simulator::spatialGridBroadphase()`
 - [ ] add multithreading
 - [ ] add cool things that can be done with clicks

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ Release build can handle about 55k particles at 60 fps, 100k particles at about
 - [x] implement SpatialGrid class and move some stuff out of
   `Simulator::spatialGridBroadphase()`
 - [x] change particle drawing to vertex-based
+- [x] add radial push
+- [ ] MAYBE add orbiting
 - [ ] fix particles exploding when compacted w/ Verlet integration
 - [ ] add multithreading
-- [ ] add cool things that can be done with clicks
 - [ ] add rigidbody mechanics
 - [ ] optimize spatial grid broad-phase
 - [ ] MAYBE improve wall collision code by only checking particles along the

--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@
 This is my attempt at building a particle simulator. I made this to practice
 applying physics to code and to practice algorithms. But probably most of all
 this just felt like a fun project to make. My goal is to be able to run the 2D
-simulation with 100k particles at at least 60 fps.
+simulation with 100k particles at 60 fps.
 
 ## Building
 
 The UI uses SFML 3.0.1, so make sure you have all the dependencies installed:
 
-Debian/Ubuntu:
+### Debian/Ubuntu:
+
 ```
 sudo apt update
 sudo apt install \
@@ -25,7 +26,8 @@ sudo apt install \
     libfreetype-dev
 ```
 
-Fedora:
+### Fedora:
+
 ```
 sudo dnf update
 sudo dnf install \
@@ -40,27 +42,29 @@ sudo dnf install \
     mesa-libEGL-devel
 ```
 
-After all the dependencies are installed, run the following commands from the
-root to configure and build the project in debug mode:
-```
-cmake -B build .
-make -C build
-```
-The executable will be called `RPEngineDebug`.
+After all dependencies are installed, just configure the project as normal:
 
-If you want to build the release version, simply use the CMAKE_BUILD_TYPE flag
-when configuring with cmake. You do the following to configure for release:
 ```
-cmake -DCMAKE_BUILD_TYPE=release -B build .
+cmake -B build .  # or however you do it
 ```
-And then run `make` as normal. The release executable is called `RPEngine`.
+
+From here you can either build the debug or release executables:
+
+```
+make -C build release  (configure for release and build)
+make -C build debug    (configure for debug and build)
+```
 
 ## State of Simulation Performance
-My laptop is an Asus VivoBook, AMD Ryzen 5800HS, 12 GB RAM. Currently, the debug
-build can handle about 13k particles at 60 fps on it, and the release build can
-handle about 55k particles at 60 fps, 100k particles at about 31 fps on it.
+
+My laptop is an Asus VivoBook with AMD Ryzen 5800HS processor (integrated
+graphics), 12 GB RAM. Currently:
+
+- Debug: 13k particles at 60 fps.
+- Release: 55k particles at 60 fps. 100k at ~31 fps.
 
 ## Controls
+
 There's only some pretty rudimentary controls at the moment:
 
 - _Spawn a single particle_ -> __right click__ anywhere on the screen.
@@ -76,6 +80,7 @@ slider (describes how much kinetic energy is lost on collision) to manipulate
 the simulation some more.
 
 ## TODO
+
 - [ ] __NEXT__ fix particles exploding when compacted w/ Verlet integration
 - [ ] use ImGui to add controls for toggling between simulating different ways
 - [ ] add support for Winblows

--- a/README.md
+++ b/README.md
@@ -12,11 +12,16 @@
 - [x] add a Verlet integration based resolver to `Simulator`
 - [x] implement spatial grid broad-phase
 - [x] add debug and release builds
+- [ ] implement SpatialGrid class and move some stuff out of
+  `Simulator::spatialGridBroadphase()`
 - [ ] add multithreading
 - [ ] add cool things that can be done with clicks
 - [ ] add rigidbody mechanics
 - [ ] optimize spatial grid broad-phase
-- [ ] MAYBE improve wall collision code by only checking particles along the walls or something
-- [ ] add a UI option for toggling between Euler-Impulse and Verlet-Position based collisions
-- [ ] add a UI option for toggling between broad phase methods for collision detection
+- [ ] MAYBE improve wall collision code by only checking particles along the
+  walls or something
+- [ ] add a UI option for toggling between Euler-Impulse and Verlet-Position
+  based collisions
+- [ ] add a UI option for toggling between broad phase methods for collision
+  detection
 - [ ] add some kind of profiler that runs a simulation without UI

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Release build can handle about 55k particles at 60 fps, 100k particles at about
 - [x] implement SpatialGrid class and move some stuff out of
   `Simulator::spatialGridBroadphase()`
 - [x] change particle drawing to vertex-based
+- [ ] fix particles exploding when compacted w/ Verlet integration
 - [ ] add multithreading
 - [ ] add cool things that can be done with clicks
 - [ ] add rigidbody mechanics

--- a/README.md
+++ b/README.md
@@ -1,29 +1,88 @@
-# RPEngine2D
+# RPEngine
 
-Debug build can handle about 13k particles at 60 fps on my machine.
+This is my attempt at building a particle simulator. I made this to practice
+applying physics to code and to practice algorithms. But probably most of all
+this just felt like a fun project to make. My goal is to be able to run the 2D
+simulation with 100k particles at at least 60 fps.
 
-Release build can handle about 55k particles at 60 fps, 100k particles at about
-31 fps on my machine.
+## Building
+
+The UI uses SFML 3.0.1, so make sure you have all the dependencies installed:
+
+Debian/Ubuntu:
+```
+sudo apt update
+sudo apt install \
+    libxrandr-dev \
+    libxcursor-dev \
+    libxi-dev \
+    libudev-dev \
+    libfreetype-dev \
+    libflac-dev \
+    libvorbis-dev \
+    libgl1-mesa-dev \
+    libegl1-mesa-dev \
+    libfreetype-dev
+```
+
+Fedora:
+```
+sudo dnf update
+sudo dnf install \
+    libXrandr-devel \
+    libXcursor-devel \
+    libXi-devel \
+    systemd-devel \
+    freetype-devel \
+    flac-devel \
+    libvorbis-devel \
+    mesa-libGL-devel \
+    mesa-libEGL-devel
+```
+
+After all the dependencies are installed, run the following commands from the
+root to configure and build the project in debug mode:
+```
+cmake -B build .
+make -C build
+```
+The executable will be called `RPEngineDebug`.
+
+If you want to build the release version, simply use the CMAKE_BUILD_TYPE flag
+when configuring with cmake. You do the following to configure for release:
+```
+cmake -DCMAKE_BUILD_TYPE=release -B build .
+```
+And then run `make` as normal. The release executable is called `RPEngine`.
+
+## State of Simulation Performance
+My laptop is an Asus VivoBook, AMD Ryzen 5800HS, 12 GB RAM. Currently, the debug
+build can handle about 13k particles at 60 fps on it, and the release build can
+handle about 55k particles at 60 fps, 100k particles at about 31 fps on it.
+
+## Controls
+There's only some pretty rudimentary controls at the moment:
+
+- _Spawn a single particle_ -> __right click__ anywhere on the screen.
+- _Begin randomly spawning particles_ -> __press R__.
+- _Randomly spawn particles 5x faster_ -> __press F__.
+- _Spawn particle in an oscillating stream_ -> __press Space__.
+- _Spawn `capacity` number of particle_ -> __press M__.
+- _Radially push particles from mouse_ -> __hold fown left click__. you can move
+  your mouse around and it will continue applying.
+
+Apart from these controls there is also a gravity and coefficient of restitution
+slider (describes how much kinetic energy is lost on collision) to manipulate
+the simulation some more.
 
 ## TODO
-
-- [x] implement working `QuadTree`
-- [x] make custom `AABB` struct independent of SFML
-- [x] change implementation `QuadTree` to use `AABB` instead of SFML `FloatRect`
-- [x] optimize number capacity of `QuadTree` partition
-- [x] move UI stuff into its own rendering engine class
-- [x] decouple simulation code from UI code
-- [x] implement proper resizing
-- [x] add a Verlet integration based resolver to `Simulator`
-- [x] implement spatial grid broad-phase
-- [x] add debug and release builds
-- [x] implement SpatialGrid class and move some stuff out of
-  `Simulator::spatialGridBroadphase()`
-- [x] change particle drawing to vertex-based
-- [x] add radial push
+- [ ] __NEXT__ fix particles exploding when compacted w/ Verlet integration
+- [ ] use ImGui to add controls for toggling between simulating different ways
+- [ ] add support for Winblows
+- [ ] implement hot-reloading for quicker debugging
+- [ ] add 3D particle simulation
 - [ ] BIG add instructions for controls!!!
 - [ ] MAYBE add orbiting
-- [ ] fix particles exploding when compacted w/ Verlet integration
 - [ ] add multithreading
 - [ ] add rigidbody mechanics
 - [ ] optimize spatial grid broad-phase
@@ -34,3 +93,17 @@ Release build can handle about 55k particles at 60 fps, 100k particles at about
 - [ ] add a UI option for toggling between broad phase methods for collision
   detection
 - [ ] add some kind of profiler that runs a simulation without UI
+- [x] add radial push
+- [x] change particle drawing to vertex-based
+- [x] implement SpatialGrid class and move some stuff out of
+  `Simulator::spatialGridBroadphase()`
+- [x] add debug and release builds
+- [x] implement spatial grid broad-phase
+- [x] add a Verlet integration based resolver to `Simulator`
+- [x] implement proper resizing
+- [x] move UI stuff into its own rendering engine class
+- [x] decouple simulation code from UI code
+- [x] optimize number capacity of `QuadTree` partition
+- [x] change implementation `QuadTree` to use `AABB` instead of SFML `FloatRect`
+- [x] make custom `AABB` struct independent of SFML
+- [x] implement working `QuadTree`

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # RPEngine2D
 
+Debug build can handle about 13k particles at 60 fps on my machine.
+
+Release build can handle about 55k particles at 60 fps, 100k particles at about
+31 fps on my machine.
+
 ## TODO
 
 - [x] implement working `QuadTree`
@@ -14,6 +19,7 @@
 - [x] add debug and release builds
 - [x] implement SpatialGrid class and move some stuff out of
   `Simulator::spatialGridBroadphase()`
+- [x] change particle drawing to vertex-based
 - [ ] add multithreading
 - [ ] add cool things that can be done with clicks
 - [ ] add rigidbody mechanics

--- a/include/Simulator.hpp
+++ b/include/Simulator.hpp
@@ -20,18 +20,22 @@ class Simulator {
             IntegrationType integrationType, BroadphaseType broadphaseType,
             size_t maxParticles = 100000);
 
-  void setWorldSize(Vec2f size) noexcept { worldSize_ = size; };
-  Vec2f worldSize() const noexcept { return worldSize_; };
-  void setDeltaTime(float dt) noexcept { dt_ = dt; };
-  float maxParticleRadius() const noexcept { return maxParticleRadius_; };
+  void setWorldSize(Vec2f size) noexcept { worldSize_ = size; }
+  Vec2f worldSize() const noexcept { return worldSize_; }
+  void setDeltaTime(float dt) noexcept { dt_ = dt; }
+  float maxParticleRadius() const noexcept { return maxParticleRadius_; }
 
   void spawnParticle(Vec2f pos, Vec2f vel, float r = 10.0f,
                      float m = 1.0f) noexcept;
   void update() noexcept;
-  const std::vector<Particle>& particles() const noexcept {
-    return particles_;
-  };
-  size_t capacity() const noexcept { return capacity_; };
+  const std::vector<Particle>& particles() const noexcept { return particles_; }
+  size_t capacity() const noexcept { return capacity_; }
+  void setIntegrationType(IntegrationType integrationType) noexcept {
+    integrationType_ = integrationType;
+  }
+  void setBroadphaseType(BroadphaseType broadphaseType) noexcept {
+    broadphaseType_ = broadphaseType;
+  }
 
  private:
   std::mt19937 gen_;

--- a/include/Simulator.hpp
+++ b/include/Simulator.hpp
@@ -38,6 +38,9 @@ class Simulator {
     broadphaseType_ = broadphaseType;
   }
 
+  void radialPush(const Vec2f& origin, const float mag = 1000.0f,
+                  const int scale = 1);
+
  private:
   std::mt19937 gen_;
   Vec2f worldSize_;

--- a/include/Simulator.hpp
+++ b/include/Simulator.hpp
@@ -20,6 +20,7 @@ class Simulator {
             IntegrationType integrationType, BroadphaseType broadphaseType,
             size_t maxParticles = 100000);
 
+  void configure(Vec2f size, float dt = 1.0f / 60.0f);
   void setWorldSize(Vec2f size) noexcept { worldSize_ = size; }
   Vec2f worldSize() const noexcept { return worldSize_; }
   void setDeltaTime(float dt) noexcept { dt_ = dt; }
@@ -46,6 +47,7 @@ class Simulator {
   IntegrationType integrationType_;
   BroadphaseType broadphaseType_;
 
+  SpatialGrid spatialGrid_;
   size_t capacity_;
 
   // broad-phase

--- a/include/Simulator.hpp
+++ b/include/Simulator.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 enum class IntegrationType { Euler, Verlet };
+enum class BroadphaseType { Naive, Qtree, UniformGrid };
 
 class Simulator {
  public:
@@ -16,7 +17,8 @@ class Simulator {
   float restitution;
 
   Simulator(Vec2f dims, float maxParticleRadius, float g, float C_r, float dt,
-            IntegrationType integrationType, size_t maxParticles = 100000);
+            IntegrationType integrationType, BroadphaseType broadphaseType,
+            size_t maxParticles = 100000);
 
   void setWorldSize(Vec2f size) noexcept { worldSize_ = size; };
   Vec2f worldSize() const noexcept { return worldSize_; };
@@ -38,6 +40,7 @@ class Simulator {
   std::vector<Particle> particles_;
   float dt_;
   IntegrationType integrationType_;
+  BroadphaseType broadphaseType_;
 
   size_t capacity_;
 

--- a/include/dsa/SpatialGrid.hpp
+++ b/include/dsa/SpatialGrid.hpp
@@ -51,6 +51,51 @@ struct SpatialGrid {
       head[c] = i;
     }
   }
+
+  template <typename Fn>
+  inline void queryDoSomething(size_t objIdx, const Vec2f& pos, Fn&& callback,
+                               int scale = 1) {
+    const int cx =
+        std::clamp(static_cast<int>(pos.x * invCellSize), 0, cols - 1);
+    const int cy =
+        std::clamp(static_cast<int>(pos.y * invCellSize), 0, rows - 1);
+
+    // precompute valid neighbor ranges
+    int dxMin;
+    int dxMax;
+    int dyMin;
+    int dyMax;
+    if (scale == 0) {
+      return;
+    } else if (scale == 1) {
+      dxMin = (cx > 0) ? -1 : 0;
+      dxMax = (cx < cols - 1) ? 1 : 0;
+      dyMin = (cy > 0) ? -1 : 0;
+      dyMax = (cy < rows - 1) ? 1 : 0;
+    } else {
+      dxMin = (cx - scale > 0) ? -1 * scale : 0;
+      dxMax = (cx - scale < cols - 1) ? 1 * scale : 0;
+      dyMin = (cy - scale > 0) ? -1 * scale : 0;
+      dyMax = (cy - scale < rows - 1) ? 1 * scale : 0;
+    }
+
+    // query neighbors
+    for (int dx = dxMin; dx <= dxMax; dx++) {
+      const int nx = cx + dx;
+      for (int dy = dyMin; dy <= dyMax; dy++) {
+        const int ny = cy + dy;
+        const int cn = ny * cols + nx;
+        if (cn >= static_cast<int>(head.size())) continue;
+
+        // get the second particle
+        for (int idx = head[cn]; idx != -1; idx = next[idx]) {
+          // prune redundant checks
+          if (idx <= static_cast<int>(objIdx)) continue;
+          callback(idx);
+        }
+      }
+    }
+  };
 };
 
 #endif

--- a/include/dsa/SpatialGrid.hpp
+++ b/include/dsa/SpatialGrid.hpp
@@ -1,9 +1,57 @@
 #ifndef SPATIALGRID_H
 #define SPATIALGRID_H
 
-class SpatialGrid {
- public:
- private:
+#include <algorithm>
+#include <cstddef>
+#include <dsa/Vec2.hpp>
+#include <vector>
+
+struct SpatialGrid {
+  float invCellSize_;
+  int cols_, rows_, nCells_;
+
+  std::vector<int> head_;
+  std::vector<int> next_;
+  size_t headSize_ = 0, nextSize_ = 0;
+
+  inline void configure(float cellSize, Vec2f worldSize) noexcept {
+    invCellSize_ = 1.0f / cellSize;
+    cols_ = worldSize.x * invCellSize_;
+    rows_ = worldSize.y * invCellSize_;
+    nCells_ = cols_ * rows_;
+  };
+
+  inline void resize(size_t numItems) noexcept {
+    if (headSize_ != static_cast<size_t>(nCells_)) {
+      head_.assign(nCells_, -1);
+      headSize_ = nCells_;
+    } else {
+      std::fill(head_.begin(), head_.end(), -1);
+    }
+
+    if (nextSize_ != numItems) {
+      nextSize_ = numItems;
+      next_.resize(nextSize_);
+    }
+  }
+
+  template <typename T>
+  inline void build(std::vector<T>& items) noexcept {
+    for (size_t i = 0; i < items.size(); i++) {
+      const Vec2f& pos = items[i].position;
+      int cx = static_cast<int>(pos.x * invCellSize_);
+      int cy = static_cast<int>(pos.y * invCellSize_);
+      cx = std::clamp(cx, 0, cols_ - 1);
+      cy = std::clamp(cy, 0, rows_ - 1);
+
+      // c maps grid coords to flat index in head
+      const int c = cy * cols_ + cx;
+
+      // push_front operation
+      next_[i] = head_[c];
+      head_[c] = i;
+    }
+  }
 };
 
 #endif

--- a/include/dsa/SpatialGrid.hpp
+++ b/include/dsa/SpatialGrid.hpp
@@ -7,31 +7,30 @@
 #include <vector>
 
 struct SpatialGrid {
-  float invCellSize_;
-  int cols_, rows_, nCells_;
+  float invCellSize;
+  int cols, rows, nCells;
 
-  std::vector<int> head_;
-  std::vector<int> next_;
-  size_t headSize_ = 0, nextSize_ = 0;
+  std::vector<int> head, next;
+  size_t headSize = 0, nextSize = 0;
 
   inline void configure(float cellSize, Vec2f worldSize) noexcept {
-    invCellSize_ = 1.0f / cellSize;
-    cols_ = worldSize.x * invCellSize_;
-    rows_ = worldSize.y * invCellSize_;
-    nCells_ = cols_ * rows_;
+    invCellSize = 1.0f / cellSize;
+    cols = worldSize.x * invCellSize;
+    rows = worldSize.y * invCellSize;
+    nCells = cols * rows;
   };
 
   inline void resize(size_t numItems) noexcept {
-    if (headSize_ != static_cast<size_t>(nCells_)) {
-      head_.assign(nCells_, -1);
-      headSize_ = nCells_;
+    if (headSize != static_cast<size_t>(nCells)) {
+      head.assign(nCells, -1);
+      headSize = nCells;
     } else {
-      std::fill(head_.begin(), head_.end(), -1);
+      std::fill(head.begin(), head.end(), -1);
     }
 
-    if (nextSize_ != numItems) {
-      nextSize_ = numItems;
-      next_.resize(nextSize_);
+    if (nextSize != numItems) {
+      nextSize = numItems;
+      next.resize(nextSize);
     }
   }
 
@@ -39,17 +38,17 @@ struct SpatialGrid {
   inline void build(std::vector<T>& items) noexcept {
     for (size_t i = 0; i < items.size(); i++) {
       const Vec2f& pos = items[i].position;
-      int cx = static_cast<int>(pos.x * invCellSize_);
-      int cy = static_cast<int>(pos.y * invCellSize_);
-      cx = std::clamp(cx, 0, cols_ - 1);
-      cy = std::clamp(cy, 0, rows_ - 1);
+      int cx = static_cast<int>(pos.x * invCellSize);
+      int cy = static_cast<int>(pos.y * invCellSize);
+      cx = std::clamp(cx, 0, cols - 1);
+      cy = std::clamp(cy, 0, rows - 1);
 
       // c maps grid coords to flat index in head
-      const int c = cy * cols_ + cx;
+      const int c = cy * cols + cx;
 
       // push_front operation
-      next_[i] = head_[c];
-      head_[c] = i;
+      next[i] = head[c];
+      head[c] = i;
     }
   }
 };

--- a/include/ui/Renderer.hpp
+++ b/include/ui/Renderer.hpp
@@ -33,18 +33,21 @@ class Renderer {
   sf::Clock runtimeClock_;
   std::vector<std::optional<sf::Color>> colorLUT_;
 
-  // assets
+  // --- assets ---
   sf::Font font_;
   sf::Texture particleTexture_;
 
-  // UI components
+  // --- UI components ---
   HorizSlider gSlider_;
   HorizSlider eSlider_;
   sf::Text particleCountText_;
   sf::Text fpsText_;
-  sf::CircleShape particleShape_;
 
-  // other variables
+  // vertex based circle drawing
+  sf::VertexArray particleVertices_;
+  static constexpr size_t CIRCLE_SEGMENTS = 12;
+
+  // --- other variables ---
   float particleSize_ = 5.0f;
   bool draggingAny_ = false;
 
@@ -63,7 +66,7 @@ class Renderer {
   size_t frameIndex_ = 0;
   bool samplesCollected_ = false;
 
-  // helper functions
+  // --- helpers ---
   const sf::Color getRainbow(float t) noexcept;
   const sf::Color& colorFor(const Particle& p) noexcept;
   void layoutUI() noexcept;

--- a/include/ui/Renderer.hpp
+++ b/include/ui/Renderer.hpp
@@ -28,9 +28,14 @@ class Renderer {
   Simulator& sim_;
   sf::RenderWindow window_;
   sf::Vector2u lastSize_;
+  sf::Vector2f pushOrigin_;  // tracks mouse position when held down
+
+  // timers
   sf::Clock frameClock_;
   sf::Clock spawnClock_;
   sf::Clock runtimeClock_;
+
+  // color lookup table
   std::vector<std::optional<sf::Color>> colorLUT_;
 
   // --- assets ---
@@ -52,6 +57,7 @@ class Renderer {
   // --- other variables ---
   float particleSize_ = 5.0f;
   bool draggingAny_ = false;
+  bool radialPushing_ = false;
 
   const float spawnInterval_ = 0.001f;
   bool streamSpawn_ = false;
@@ -89,6 +95,7 @@ class Renderer {
   void randomSpawnSUPERFAST() noexcept;
   void streamSpawn() noexcept;
   void spawnMax() noexcept;
+  void radialPush();
 };
 
 #endif

--- a/include/ui/Renderer.hpp
+++ b/include/ui/Renderer.hpp
@@ -31,7 +31,7 @@ class Renderer {
   sf::Clock frameClock_;
   sf::Clock spawnClock_;
   sf::Clock runtimeClock_;
-  std::unordered_map<uint32_t, sf::Color> colorLUT_;
+  std::vector<std::optional<sf::Color>> colorLUT_;
 
   // assets
   sf::Font font_;

--- a/include/ui/Renderer.hpp
+++ b/include/ui/Renderer.hpp
@@ -45,7 +45,9 @@ class Renderer {
 
   // vertex based circle drawing
   sf::VertexArray particleVertices_;
-  static constexpr size_t CIRCLE_SEGMENTS = 12;
+  static constexpr size_t MIN_CIRCLE_SEGMENTS = 6;
+  static constexpr size_t MAX_CIRCLE_SEGMENTS = 24;
+  size_t getCircleSegments(float radius);
 
   // --- other variables ---
   float particleSize_ = 5.0f;

--- a/include/ui/Renderer.hpp
+++ b/include/ui/Renderer.hpp
@@ -47,7 +47,7 @@ class Renderer {
   sf::VertexArray particleVertices_;
   static constexpr size_t MIN_CIRCLE_SEGMENTS = 6;
   static constexpr size_t MAX_CIRCLE_SEGMENTS = 24;
-  size_t getCircleSegments(float radius);
+  std::array<std::vector<sf::Vector2f>, MAX_CIRCLE_SEGMENTS + 1> unitCircle_;
 
   // --- other variables ---
   float particleSize_ = 5.0f;
@@ -69,6 +69,9 @@ class Renderer {
   bool samplesCollected_ = false;
 
   // --- helpers ---
+  void computeUnitCircle();
+  size_t getCircleSegments(float radius);
+
   const sf::Color getRainbow(float t) noexcept;
   const sf::Color& colorFor(const Particle& p) noexcept;
   void layoutUI() noexcept;

--- a/src/Simulator.cpp
+++ b/src/Simulator.cpp
@@ -80,6 +80,7 @@ void Simulator::qtreeBroadphase(size_t bucketSize) {
   }
 }
 
+// O(n)
 void Simulator::spatialGridBroadphase() {
   float cellSize = 2.0f * maxParticleRadius_;
   float invCellSize = 1.0f / cellSize;  // no divisions w/ cellSize reciprocal
@@ -266,9 +267,20 @@ void Simulator::particleCollision(Particle& p1, Particle& p2) {
 
 void Simulator::resolveCollisions() {
   auto [w, h] = worldSize_;
-  for (Particle& par : particles_) {
-    applyWall(par, w, h);
+  if (broadphaseType_ == BroadphaseType::UniformGrid) {
+    for (Particle& par : particles_) {
+      applyWall(par, w, h);
+    }
+    spatialGridBroadphase();
+  } else if (broadphaseType_ == BroadphaseType::Qtree) {
+    for (Particle& par : particles_) {
+      applyWall(par, w, h);
+    }
+    qtreeBroadphase(16);
+  } else {
+    for (Particle& par : particles_) {
+      applyWall(par, w, h);
+    }
+    naiveBroadphase();
   }
-  // qtreeBroadphase(16);
-  spatialGridBroadphase();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@ int main() {
   // Simulator sim({0.0f, 0.0f}, 2.0f, 0.0f, 0.0f, 0.0f, IntegrationType::Euler,
   // 100000);
   Simulator sim({0.0f, 0.0f}, 2.0f, 0.0f, 0.0f, 0.0, IntegrationType::Verlet,
-                BroadphaseType::UniformGrid, 20000);
+                BroadphaseType::UniformGrid, 13000);
 
   Renderer renderer(sim, Renderer::Options{60, "RPEngine"});
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@ int main() {
   // Simulator sim({0.0f, 0.0f}, 2.0f, 0.0f, 0.0f, 0.0f, IntegrationType::Euler,
   // 100000);
   Simulator sim({0.0f, 0.0f}, 2.0f, 0.0f, 0.0f, 0.0, IntegrationType::Verlet,
-                BroadphaseType::UniformGrid, 10000);
+                BroadphaseType::UniformGrid, 20000);
 
   Renderer renderer(sim, Renderer::Options{60, "RPEngine"});
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,7 +6,7 @@ int main() {
   // Simulator sim({0.0f, 0.0f}, 2.0f, 0.0f, 0.0f, 0.0f, IntegrationType::Euler,
   // 100000);
   Simulator sim({0.0f, 0.0f}, 10.0f, 0.0f, 0.0f, 0.0, IntegrationType::Verlet,
-                BroadphaseType::UniformGrid, 10000);
+                BroadphaseType::UniformGrid, 3000);
 
   Renderer renderer(sim, Renderer::Options{60, "RPEngine"});
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,9 +2,11 @@
 #include <ui/Renderer.hpp>
 
 int main() {
-	// NOTE: running sim w/ Euler integration makes some really cool fx
-  // Simulator sim({0.0f, 0.0f}, 2.0f, 0.0f, 0.0f, 0.0f, IntegrationType::Euler, 100000);
-  Simulator sim({0.0f, 0.0f}, 2.0f, 0.0f, 0.0f, 0.0, IntegrationType::Verlet, 100000);
+  // NOTE: running sim w/ Euler integration makes some really cool fx
+  // Simulator sim({0.0f, 0.0f}, 2.0f, 0.0f, 0.0f, 0.0f, IntegrationType::Euler,
+  // 100000);
+  Simulator sim({0.0f, 0.0f}, 2.0f, 0.0f, 0.0f, 0.0, IntegrationType::Verlet,
+                BroadphaseType::UniformGrid, 10000);
 
   Renderer renderer(sim, Renderer::Options{60, "RPEngine"});
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,8 +5,8 @@ int main() {
   // NOTE: running sim w/ Euler integration makes some really cool fx
   // Simulator sim({0.0f, 0.0f}, 2.0f, 0.0f, 0.0f, 0.0f, IntegrationType::Euler,
   // 100000);
-  Simulator sim({0.0f, 0.0f}, 2.0f, 0.0f, 0.0f, 0.0, IntegrationType::Verlet,
-                BroadphaseType::UniformGrid, 13000);
+  Simulator sim({0.0f, 0.0f}, 10.0f, 0.0f, 0.0f, 0.0, IntegrationType::Verlet,
+                BroadphaseType::UniformGrid, 10000);
 
   Renderer renderer(sim, Renderer::Options{60, "RPEngine"});
 

--- a/src/ui/Renderer.cpp
+++ b/src/ui/Renderer.cpp
@@ -71,7 +71,10 @@ void Renderer::drawFrame() {
   window_.display();
 }
 
-
+size_t Renderer::getCircleSegments(float radius) {
+  const size_t segments = radius * 1.5f + MIN_CIRCLE_SEGMENTS;
+  return std::clamp(segments, MIN_CIRCLE_SEGMENTS, MAX_CIRCLE_SEGMENTS);
+}
 
 const sf::Color Renderer::getRainbow(float t) noexcept {
   const float r = sin(t);
@@ -178,7 +181,11 @@ void Renderer::handleKeyPressed(const sf::Event::KeyPressed& e) noexcept {
 }
 
 void Renderer::drawParticles() {
-  const size_t vertexCount = sim_.particles().size() * CIRCLE_SEGMENTS * 3;
+  size_t vertexCount = 0;
+  for (const Particle& par : sim_.particles()) {
+    const size_t segments = getCircleSegments(par.radius);
+    vertexCount += segments * 3;
+  }
 
   // resize if needed
   if (particleVertices_.getVertexCount() < vertexCount) {
@@ -189,11 +196,12 @@ void Renderer::drawParticles() {
   for (const Particle& par : sim_.particles()) {
     const Vec2f& pos = par.position;
     const sf::Color& color = colorFor(par);
+    const size_t segments = getCircleSegments(par.radius);
 
     // build circle triangles
-    for (size_t k = 0; k < CIRCLE_SEGMENTS; k++) {
-      const float theta1 = 2.0f * PI * k / CIRCLE_SEGMENTS;
-      const float theta2 = 2.0f * PI * (k + 1) / CIRCLE_SEGMENTS;
+    for (size_t k = 0; k < segments; k++) {
+      const float theta1 = 2.0f * PI * k / segments;
+      const float theta2 = 2.0f * PI * (k + 1) / segments;
 
       particleVertices_[vertexIdx] =
           sf::Vertex{sf::Vector2f(pos.x, pos.y), color};

--- a/src/ui/Renderer.cpp
+++ b/src/ui/Renderer.cpp
@@ -197,11 +197,8 @@ void Renderer::handleKeyPressed(const sf::Event::KeyPressed& e) noexcept {
 }
 
 void Renderer::drawParticles() {
-  size_t vertexCount = 0;
-  for (const Particle& par : sim_.particles()) {
-    const size_t segments = getCircleSegments(par.radius);
-    vertexCount += segments * 3;
-  }
+  const size_t segments = getCircleSegments(particleSize_);
+  size_t vertexCount = segments * 3 * sim_.particles().size();
 
   // resize if needed
   if (particleVertices_.getVertexCount() < vertexCount) {
@@ -212,14 +209,13 @@ void Renderer::drawParticles() {
   for (const Particle& par : sim_.particles()) {
     const Vec2f& pos = par.position;
     const sf::Color& color = colorFor(par);
-    const size_t s = getCircleSegments(par.radius);
 
     // transform unit circle vertices
-    for (size_t i = 0; i < s; i++) {
-      const sf::Vector2f& vertex = unitCircle_[s][i];
+    const std::vector<sf::Vector2f>& vertices = unitCircle_[segments];
+    for (size_t i = 0; i < vertices.size(); i++) {
       particleVertices_[vertexIdx] =
-          sf::Vertex{sf::Vector2f(pos.x + par.radius * vertex.x,
-                                  pos.y + par.radius * vertex.y),
+          sf::Vertex{sf::Vector2f(pos.x + par.radius * vertices[i].x,
+                                  pos.y + par.radius * vertices[i].y),
                      color};
       vertexIdx++;
     }

--- a/src/ui/Renderer.cpp
+++ b/src/ui/Renderer.cpp
@@ -13,9 +13,9 @@ Renderer::Renderer(Simulator& sim, const Options& opts)
       fpsText_(font_, "FPS: 60", 30) {
   window_.setFramerateLimit(opts.fps_limit);
   lastSize_ = window_.getSize();
-  sim_.setWorldSize(
-      Vec2f(static_cast<float>(lastSize_.x), static_cast<float>(lastSize_.y)));
-  sim_.setDeltaTime(1.0f / static_cast<float>(opts.fps_limit));
+  sim_.configure(
+      {static_cast<float>(lastSize_.x), static_cast<float>(lastSize_.y)},
+      1.0f / static_cast<float>(opts.fps_limit));
 
   gen_ = std::mt19937(std::random_device{}());
   distX = std::uniform_real_distribution<float>(0.0f, lastSize_.x - 20.0f);


### PR DESCRIPTION
I kinda deviated from the purpose of the branch and added some other stuff like radial pushing and changed how to build project.

### Performance Improvements

#### `spatialGridBroadphase`

1. moved most of the code into `SpatialGrid` class.
2. precomputed unit circle for certain number of vertices to reduce the use of cosine and sine at runtime
3. kind of precompute valid neighbor ranges for particles that could collide

I also added a query function that uses a callback mechanism, this definitely doesn't improve performance but it certainly makes my code easier to read (at least I think lol).

#### Color lookup table for particles

Instead of using an unordered map for `colorLUT_` in `Renderer`, I switched it to use a vector instead. This helped a lot as now there's less cache misses. It's also now based on each particle's ID, and it's tighter in memory.

#### Drawing particles using `sf::Triangle` approximation

Header pretty much says it all. Instead of using `sf::CircleShape` to draw each particle, I now use triangles to draw a particle by determining the number of segments it should have, use the precomputed unit circle for that number of segments, and transform those unit circle coordinates to where the particle should be. I use the transformed points to construct triangles that approximate the particle, and store those vertices in a `sf::VertexArray`. From there I just call the window's draw method with the vertex array as input. One big draw as opposed to n `sf::CircleShape` draws. This hugely improved performance.